### PR TITLE
Change how types are processed to avoid gobs of memory usage

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -11,5 +11,6 @@
 	},
 	"description": "A library to handle the GraphQL Protocol",
 	"copyright": "Copyright © 2019, Robert burner Schadek",
-	"license": "LGPL3"
+	"license": "LGPL3",
+	"dflags": ["--DRT-gcopt=profile:1", "-lowmem"]
 }

--- a/dub.json
+++ b/dub.json
@@ -11,6 +11,5 @@
 	},
 	"description": "A library to handle the GraphQL Protocol",
 	"copyright": "Copyright © 2019, Robert burner Schadek",
-	"license": "LGPL3",
-	"dflags": ["--DRT-gcopt=profile:1", "-lowmem"]
+	"license": "LGPL3"
 }

--- a/source/graphql/helper.d
+++ b/source/graphql/helper.d
@@ -732,10 +732,8 @@ string getTypename(Schema,T)(auto ref T input) @trusted {
 		import graphql.reflection;
 		auto tinfo = typeid(input);
 		auto reflect = SchemaReflection!Schema.instance;
-		while(tinfo !is null)
-		{
-			if(auto cname = tinfo in reflect.classes)
-			{
+		while(tinfo !is null) {
+			if(auto cname = tinfo in reflect.classes) {
 				return *cname;
 			}
 			tinfo = tinfo.base;

--- a/source/graphql/reflection.d
+++ b/source/graphql/reflection.d
@@ -1,0 +1,84 @@
+module graphql.reflection;
+import graphql.traits;
+import std.traits;
+import std.meta;
+import vibe.data.json;
+
+package struct SchemaReflection(Schema)
+{
+	static SchemaReflection *instance() @safe
+	{
+		_instance.initialize();
+		return &_instance;
+	}
+
+	string[TypeInfo] classes;
+	string[][TypeInfo] derivatives;
+	string[][string] bases;
+	static struct TypeWithStrippedName
+	{
+		Json typeJson;
+		string name;
+		bool canonical;
+	}
+	TypeWithStrippedName[string] jsonTypes;
+
+
+	private:
+	static SchemaReflection _instance;
+
+	bool initialized;
+
+	static void builder(T)(ref SchemaReflection ths)
+	{
+		static if(is(T == class))
+		{
+			ths.classes[typeid(T)] = T.stringof;
+			static foreach(B; AliasSeq!(T, TransitiveBaseTypeTuple!T))
+			{
+				static if(!is(B == Object))
+				{
+					ths.derivatives.require(typeid(B), null) ~= T.stringof;
+					ths.bases.require(T.stringof, null) ~= B.stringof;
+				}
+			}
+		}
+		else static if(is(T == interface))
+		{
+			// go through all base types, and set up the derivation lines
+			static foreach(B; AliasSeq!(T, InterfacesTuple!T))
+			{
+				ths.derivatives.require(typeid(B), null) ~= T.stringof;
+				ths.bases.require(T.stringof, null) ~= B.stringof;
+			}
+		}
+		else
+		{
+			// all other types have derivatives and bases of themselves
+			ths.derivatives.require(typeid(T), null) ~= T.stringof;
+			ths.bases.require(T.stringof, null) ~= T.stringof;
+		}
+
+	}
+
+	static void builderPhase2(T)(ref SchemaReflection ths)
+	{
+		import graphql.schema.typeconversions : typeToTypeName, typeToJsonImpl;
+		// build the second parts which need the first parts
+		alias stripped = stripArrayAndNullable!T;
+		ths.jsonTypes[typeToTypeName!T] =
+			TypeWithStrippedName(typeToJsonImpl!(stripped, Schema, T)(),
+								 stripped.stringof,
+								 is(stripArrayAndNullable!T == T));
+	}
+
+	void initialize() @safe
+	{
+		if(initialized)
+			return;
+		initialized = true;
+
+		execForAllTypes!(Schema, builder)(this);
+		execForAllTypes!(Schema, builderPhase2)(this);
+	}
+}

--- a/source/graphql/schema/resolver.d
+++ b/source/graphql/schema/resolver.d
@@ -213,11 +213,9 @@ void setDefaultSchemaResolver(T, Con)(GraphQLD!(T,Con) graphql) {
 
 	alias resolverFunction = Json function(ref const(StringTypeStrip), Json, GraphQLD!(T,Con)) @safe;
 	static resolverFunction[string] handlers;
-	if(handlers is null)
-	{
+	if(handlers is null) {
 		static void processType(type)(ref resolverFunction[string] handlers) {
-			static if(!is(type == void))
-			{
+			static if(!is(type == void)) {
 				enum typeConst = typeToTypeName!(type);
 				handlers[typeConst] = &typeResolverImpl!(type);
 			}
@@ -261,8 +259,7 @@ void setDefaultSchemaResolver(T, Con)(GraphQLD!(T,Con) graphql) {
 			stripType = typeCap.stringTypeStrip();
 			graphql.defaultResolverLog.logf("%s %s", __LINE__, stripType);
 
-			if(auto h = stripType.str in handlers)
-			{
+			if(auto h = stripType.str in handlers) {
 				ret = (*h)(stripType, parent, graphql);
 			}
 			retLabel:
@@ -294,24 +291,19 @@ void setDefaultSchemaResolver(T, Con)(GraphQLD!(T,Con) graphql) {
 				typeResolverImpl!(__Directive)(stripType, parent, graphql)["data"];
 			ret["data"]["types"] ~=
 				typeResolverImpl!(__DirectiveLocation)(stripType, parent,
-													   graphql)
-					["data"];
+														graphql)["data"];
 
 			Json jsonTypes;
 			jsonTypes = Json.emptyArray;
-			static if(hasMember!(T, Constants.directives))
-			{
+			static if(hasMember!(T, Constants.directives)) {
 				import graphql.schema.typeconversions : typeToTypeName;
 				string directiveTypeName =
 			   	   typeToTypeName!(typeof(__traits(getMember, T,
 												   Constants.directives)));
-			}
-			else
-			{
+			} else {
 				string directiveTypeName = "";
 			}
-			foreach(n, ref tsn; SchemaReflection!T.instance.jsonTypes)
-			{
+			foreach(n, ref tsn; SchemaReflection!T.instance.jsonTypes) {
 				if(n != directiveTypeName && tsn.canonical)
 					jsonTypes ~= tsn.typeJson.clone;
 			}

--- a/source/graphql/schema/typeconversions.d
+++ b/source/graphql/schema/typeconversions.d
@@ -421,20 +421,16 @@ Json typeToJsonImpl(Type,Schema,Orig)() {
 		}
 		else
 		{
+			import graphql.reflection;
 			// need to search for all types that we support that are derived
 			// from this type
-			static Json derivedTypes;
-			if(derivedTypes.type == Json.Type.undefined)
+			ret[Constants.possibleTypesNames] = Json.emptyArray();
+			foreach(tname;
+					SchemaReflection!Schema.instance.derivatives.get(typeid(Type),
+																	 null))
 			{
-				derivedTypes = Json.emptyArray();
-				static void checkType(U)(ref Json dt)
-				{
-					static if(is(U : Type))
-						dt ~= U.stringof;
-				}
-				execForAllTypes!(Schema, checkType)(derivedTypes);
+				ret[Constants.possibleTypesNames] ~= tname;
 			}
-			ret[Constants.possibleTypesNames] = derivedTypes.clone;
 		}
 	} else {
 		ret[Constants.possibleTypesNames] = Json(null);

--- a/source/graphql/schema/typeconversions.d
+++ b/source/graphql/schema/typeconversions.d
@@ -407,20 +407,14 @@ Json typeToJsonImpl(Type,Schema,Orig)() {
 	}
 
 	// needed to resolve possibleTypes
-	static if(is(Type == class) || is(Type == union)
-			|| is(Type == interface))
-	{
-		static if(is(Type == union))
-		{
+	static if(is(Type == class) || is(Type == union) || is(Type == interface)) {
+		static if(is(Type == union)) {
 			//import std.meta: Filter;
 			ret[Constants.possibleTypesNames] = Json.emptyArray();
-			static foreach(pt; Filter!(isAggregateType, FieldTypeTuple!Type))
-			{
+			static foreach(pt; Filter!(isAggregateType, FieldTypeTuple!Type)) {
 				ret[Constants.possibleTypesNames] ~= pt.stringof;
 			}
-		}
-		else
-		{
+		} else {
 			import graphql.reflection;
 			// need to search for all types that we support that are derived
 			// from this type

--- a/source/graphql/validation/schemabased.d
+++ b/source/graphql/validation/schemabased.d
@@ -113,12 +113,9 @@ class SchemaValidator(Schema) : Visitor {
 	}
 
 	void addTypeToStackImpl(string name, string followType, string old) {
-		if(auto tp = followType in typeMap)
-		{
+		if(auto tp = followType in typeMap) {
 			this.schemaStack ~= TypePlusName(tp.clone, name);
-		}
-		else
-		{
+		} else {
 			throw new UnknownTypeName(
 					  format("No type with name '%s' '%s' is known",
 							 followType, old), __FILE__, __LINE__);
@@ -129,17 +126,16 @@ class SchemaValidator(Schema) : Visitor {
 		import graphql.schema.introspectiontypes : IntrospectionTypes;
 		this.doc = doc;
 		this.schema = schema;
-		static void buildTypeMap(T)(ref Json[string] map)
-		{
-			if(is(T == stripArrayAndNullable!T))
-			{
+		static void buildTypeMap(T)(ref Json[string] map) {
+			static if(is(T == stripArrayAndNullable!T)) {
 				map[typeToTypeName!T] =
 				   	removeNonNullAndList(typeToJson!(T, Schema)());
 			}
 		}
 		execForAllTypes!(Schema, buildTypeMap)(typeMap);
-		static foreach(T; IntrospectionTypes)
+		foreach(T; IntrospectionTypes) {
 			buildTypeMap!T(typeMap);
+		}
 		this.schemaStack ~= TypePlusName(
 				removeNonNullAndList(typeToJson!(Schema,Schema)()),
 				Schema.stringof
@@ -172,12 +168,9 @@ class SchemaValidator(Schema) : Visitor {
 	override void enter(const(FragmentDefinition) fragDef) {
 		string typeName = fragDef.tc.value;
 		//writefln("%s %s", typeName, fragDef.name.value);
-		if(auto tp = typeName in typeMap)
-		{
+		if(auto tp = typeName in typeMap) {
 			this.schemaStack ~= TypePlusName(tp.clone, typeName);
-		}
-		else
-		{
+		} else {
 			throw new UnknownTypeName(
 					  format("No type with name '%s' is known", typeName),
 					  __FILE__, __LINE__);


### PR DESCRIPTION
Memory usage of the compiler is way high for graphql because of the usage of multiple iterations of compile-time lists to collect all relevant types of a schema. Some of the templates it uses are either linear recursive or divide-and-conquer which both result in lots of compiler memory used to track these templates.

In this version, instead of generating the list of types at compile-time, we are simply recursively calling a function alias ONCE for each type in the list. This allows us to build runtime reflection capabilities but only instantiate one template per type instead of thousands of templates. On my system, this makes a project which consumes over 10GB of memory to compile (not sure how much, I ran out of memory!) down to 3.5GB.

I expect we can possibly improve this some more, but this at least gets me compiling again.

The reflection library is haphazardly thrown together, just getting what I needed to replace `collectTypes` and is obviously inconsistent. I'm happy to modify this to fit the needs, but my first goal was simply to replace the functionality that exists today. Not being 100% certain of how the library works or the graphql spec, I didn't want to mess with anything.