### PR TITLE
Add serialization representations to GQLDCustomLeaf so the vibe seria…

### DIFF
--- a/source/graphql/uda.d
+++ b/source/graphql/uda.d
@@ -79,6 +79,15 @@ struct GQLDCustomLeaf(T, alias SerializationFun, alias DeserializationFun) {
 	void opAssign(Type value) {
 		this.value = value;
 	}
+
+	static GQLDCustomLeaf!(T, SerializationFun, DeserializationFun) fromRepresentation(T input) @safe {
+		return GQLDCustomLeaf!(T, SerializationFun, DeserializationFun)(input);
+	}
+
+	T toRepresentation() @safe {
+		return this.value;
+	}
+
 }
 
 private string tS(DateTime dt) {


### PR DESCRIPTION
Adding toRepresentation and fromRepresentation to GQLDCustomLeaf which allows vibe.d serialization to handle these objects. Useful when graphqld is used in combination with vibe. Also yes I am the same person as serates, sorry it took me so long to upload a PR for this, I had to get legal approval from my company to submit this, but happily they approved