### PR TITLE
Fix broken unittests using a workaround

### DIFF
--- a/source/graphql/uda.d
+++ b/source/graphql/uda.d
@@ -80,8 +80,13 @@ struct GQLDCustomLeaf(T, alias SerializationFun, alias DeserializationFun) {
 		this.value = value;
 	}
 
-	static GQLDCustomLeaf!(T, SerializationFun, DeserializationFun) fromRepresentation(T input) @safe {
+	GQLDCustomLeaf!(T, SerializationFun, DeserializationFun) _from(T input) @safe {
 		return GQLDCustomLeaf!(T, SerializationFun, DeserializationFun)(input);
+	}
+
+	static auto fromRepresentation(T input) @safe {
+		auto myself = typeof(this).init;
+		return myself._from(input);
 	}
 
 	T toRepresentation() @safe {


### PR DESCRIPTION
This should fix the unittest failures I introduced with my serialization fix. Its not the cleanest solution but it avoids a frame pointer access error while still fully working for its intent