### PR TITLE
Schema export: export bare types as non-nullable

### DIFF
--- a/source/graphql/schema/toschemafile.d
+++ b/source/graphql/schema/toschemafile.d
@@ -158,15 +158,15 @@ Visibility traceType(GQLDType t, ref TraceableType[string] tab) {
 	return tab[map.name].vis;
 }
 
-string gqldTypeToString(const(GQLDType) t, string nameSuffix = "") {
+string gqldTypeToString(const(GQLDType) t, string nameSuffix = "", bool nonNullable = true) {
 	if(auto base = cast(const(GQLDNullable))t) {
-		return gqldTypeToString(base.elementType, nameSuffix);
+		return gqldTypeToString(base.elementType, nameSuffix, false);
 	} else if(auto list = cast(const(GQLDList))t) {
-		return '[' ~ gqldTypeToString(list.elementType, nameSuffix) ~ ']';
+		return '[' ~ gqldTypeToString(list.elementType, nameSuffix, true) ~ ']' ~ (nonNullable ? "!" : "");
 	} else if(auto nn = cast(const(GQLDNonNull))t) {
-		return gqldTypeToString(nn.elementType, nameSuffix) ~ "!";
+		return gqldTypeToString(nn.elementType, nameSuffix, true);
 	}
-	return t.name ~ nameSuffix;
+	return t.name ~ nameSuffix ~ (nonNullable ? "!" : "");
 }
 
 string baseTypeName(const(GQLDType) t) {

--- a/source/graphql/schema/toschemafile.d
+++ b/source/graphql/schema/toschemafile.d
@@ -5,6 +5,7 @@ import std.algorithm.iteration : map, joiner;
 import std.conv : to;
 import std.stdio;
 import std.format;
+import std.typecons;
 
 import graphql.graphql;
 import graphql.schema.types;
@@ -158,13 +159,13 @@ Visibility traceType(GQLDType t, ref TraceableType[string] tab) {
 	return tab[map.name].vis;
 }
 
-string gqldTypeToString(const(GQLDType) t, string nameSuffix = "", bool nonNullable = true) {
+string gqldTypeToString(const(GQLDType) t, string nameSuffix = "", Flag!"nonNullable" nonNullable = Yes.nonNullable) {
 	if(auto base = cast(const(GQLDNullable))t) {
-		return gqldTypeToString(base.elementType, nameSuffix, false);
+		return gqldTypeToString(base.elementType, nameSuffix, No.nonNullable);
 	} else if(auto list = cast(const(GQLDList))t) {
-		return '[' ~ gqldTypeToString(list.elementType, nameSuffix, true) ~ ']' ~ (nonNullable ? "!" : "");
+		return '[' ~ gqldTypeToString(list.elementType, nameSuffix, Yes.nonNullable) ~ ']' ~ (nonNullable ? "!" : "");
 	} else if(auto nn = cast(const(GQLDNonNull))t) {
-		return gqldTypeToString(nn.elementType, nameSuffix, true);
+		return gqldTypeToString(nn.elementType, nameSuffix, Yes.nonNullable);
 	}
 	return t.name ~ nameSuffix ~ (nonNullable ? "!" : "");
 }

--- a/test/schema.gql
+++ b/test/schema.gql
@@ -5,10 +5,10 @@ schema {
 }
 scalar Date
 type Android {
-	primaryFunction: String
+	primaryFunction: String!
 }
 type subscriptionType {
-	starships: [Starship]
+	starships: [Starship!]!
 }
 enum Series {
 	TheOriginalSeries,
@@ -19,76 +19,76 @@ enum Series {
 	Discovery,
 }
 type Input {
-	first: Int
+	first: Int!
 	after: String
 }
 type Starship {
-	series: [Series]
-	id: Int
-	commander: Character
-	name: String
-	size: Float
-	crew: [Character]
-	designation: String
+	series: [Series]!
+	id: Int!
+	commander: Character!
+	name: String!
+	size: Float!
+	crew: [Character!]!
+	designation: String!
 }
 # note: nestedness of type 'Starship' not determined; output may be suboptimal
 input StarshipIn {
-	series: [Series]
-	id: Int
-	commander: CharacterIn
-	name: String
-	size: Float
-	crew: [CharacterIn]
-	designation: String
+	series: [Series]!
+	id: Int!
+	commander: CharacterIn!
+	name: String!
+	size: Float!
+	crew: [CharacterIn!]!
+	designation: String!
 }
 input AddCrewmanData {
-	shipId: Int
-	series: [Series]
-	name: String
+	shipId: Int!
+	series: [Series!]!
+	name: String!
 }
 interface Character {
 	ships: Starship
-	series: [Series]
-	id: Int
+	series: [Series!]!
+	id: Int!
 	ship: Starship
-	name: String
+	name: String!
 	allwaysNull: Starship
-	commands: [Character]
+	commands: [Character!]!
 	alsoAllwaysNull: Int
-	commanders: [Character]
+	commanders: [Character!]!
 }
 # note: nestedness of type 'Character' not determined; output may be suboptimal
 input CharacterIn {
 	ships: StarshipIn
-	series: [Series]
-	id: Int
+	series: [Series!]!
+	id: Int!
 	ship: StarshipIn
-	name: String
+	name: String!
 	allwaysNull: StarshipIn
-	commands: [CharacterIn]
+	commands: [CharacterIn!]!
 	alsoAllwaysNull: Int
-	commanders: [CharacterIn]
+	commanders: [CharacterIn!]!
 }
 type mutationType {
-	addCrewman(input: AddCrewmanData): Character
+	addCrewman(input: AddCrewmanData!): Character!
 }
 type queryType {
-	shipsselection(ids: [Int]): [Starship]
-	currentTime: DateTime
-	starships(overSize: Float): [Starship]
-	captain(series: Series): Character
-	humanoids: [Humanoid]
-	starship(id: Int): Starship
-	androids: [Android]
-	resolverWillThrow: [Android]
-	numberBetween(searchInput: Input): Starship
-	search(name: String): SearchResult
-	starshipDoesNotExist: Starship
-	character(id: Int): Character
+	shipsselection(ids: [Int!]!): [Starship!]!
+	currentTime: DateTime!
+	starships(overSize: Float!): [Starship!]!
+	captain(series: Series!): Character!
+	humanoids: [Humanoid!]!
+	starship(id: Int!): Starship
+	androids: [Android!]!
+	resolverWillThrow: [Android!]!
+	numberBetween(searchInput: Input!): Starship!
+	search(name: String!): SearchResult!
+	starshipDoesNotExist: Starship!
+	character(id: Int!): Character
 }
 type Humanoid {
-	dateOfBirth: Date
-	species: String
+	dateOfBirth: Date!
+	species: String!
 }
 scalar SearchResult
 scalar DateTime

--- a/test/schema2.gql
+++ b/test/schema2.gql
@@ -5,10 +5,12 @@ schema {
 }
 type mutationType { _: Boolean }
 type queryType {
-	foo: Int!
-	manysmall: [Small!]!
-	bar: Int!
+	maybeNull: Int
 	small: Small
+	manysmall: [Small!]!
+	neverNull: Int!
+	foo: Int!
+	bar: Int!
 }
 type subscriptionType { _: Boolean }
 type Small {

--- a/test/schema2.gql
+++ b/test/schema2.gql
@@ -5,29 +5,29 @@ schema {
 }
 type mutationType { _: Boolean }
 type queryType {
-	foo: Int
-	manysmall: [Small]
-	bar: Int
+	foo: Int!
+	manysmall: [Small!]!
+	bar: Int!
 	small: Small
 }
 type subscriptionType { _: Boolean }
 type Small {
-	id: Int
-	foobar: [SmallChild]
-	name: String
-	arg(a: Int): [SmallChild]
+	id: Int!
+	foobar: [SmallChild!]!
+	name: String!
+	arg(a: Int!): [SmallChild!]!
 }
 input SmallIn {
-	id: Int
-	foobar: [SmallChildIn]
-	name: String
+	id: Int!
+	foobar: [SmallChildIn!]!
+	name: String!
 }
 type SmallChild {
-	id: Int
-	name: String
-	foo(a: Int): Int
+	id: Int!
+	name: String!
+	foo(a: Int!): Int!
 }
 input SmallChildIn {
-	id: Int
-	name: String
+	id: Int!
+	name: String!
 }

--- a/test/source/testdata2.d
+++ b/test/source/testdata2.d
@@ -22,6 +22,9 @@ interface Query2 {
 	long bar();
 	Nullable!Small small();
 	Small[] manysmall();
+
+	Nullable!long maybeNull();
+	long neverNull();
 }
 
 interface Mutation2 {


### PR DESCRIPTION
Aside: does it make sense to have both `GQLDNullable` and `GQLDNonNullable`?  Would it make more sense for one of them be removed?