### PR TITLE
std.experimental.typecons was removed in Phobos master.

### DIFF
--- a/source/graphql/validation/querybased.d
+++ b/source/graphql/validation/querybased.d
@@ -41,7 +41,6 @@ struct OperationFragVar {
 }
 
 class QueryValidator : ConstVisitor {
-	import std.experimental.typecons : Final;
 	alias enter = ConstVisitor.enter;
 	alias exit = ConstVisitor.exit;
 	alias accept = ConstVisitor.accept;

--- a/source/graphql/validation/schemabased.d
+++ b/source/graphql/validation/schemabased.d
@@ -57,7 +57,6 @@ struct DirectiveEntry {
 }
 
 class SchemaValidator(Schema) : Visitor {
-	import std.experimental.typecons : Final;
 	import graphql.schema.typeconversions;
 	import graphql.traits;
 	import graphql.helper : StringTypeStrip, stringTypeStrip;


### PR DESCRIPTION
Looks like Final wasn't used anyway.