### PR TITLE
All custom parameter types should always be In types

### DIFF
--- a/source/graphql/schema/toschemafile.d
+++ b/source/graphql/schema/toschemafile.d
@@ -258,8 +258,8 @@ void typeImpl(Out)(ref Out o, TraceableType type, in TraceableType[string] tab) 
 	}
 
 	void dumpMem(bool inputType) {
-		string typeToStringMaybeIn(const(GQLDType) t) {
-			return gqldTypeToString(t, inputType && t.baseTypeName in tab
+		string typeToStringMaybeIn(const(GQLDType) t, bool isParam = false) {
+			return gqldTypeToString(t, (isParam || inputType) && t.baseTypeName in tab
 						&& tab[t.baseTypeName].vis != Visibility.inputOnly
 						&& tab[t.baseTypeName].vis != Visibility.inputOrOutput ? "In" : "");
 		}
@@ -280,7 +280,7 @@ void typeImpl(Out)(ref Out o, TraceableType type, in TraceableType[string] tab) 
 					formIndent(o, 1, "%s(%s): %s%s", mem
 					        , op.parameters.byKeyValue()
 								.map!(kv => format("%s: %s", kv.key
-										, typeToStringMaybeIn(kv.value)))
+										, typeToStringMaybeIn(kv.value, true)))
 								.joiner(", ")
 					            .to!string
 					        , map.name == "mutationType"


### PR DESCRIPTION
So for instance, if you have a schema like:

```d
struct Query {
   long foo(MyCustomType t);
}
```
The current code will generate the graphql file with `foo` being typed like: `foo(t: MyCustomType) : Int`, but it needs to be `foo(t: MyCustomTypeIn)`, since all parameters must be input types or scalars. (see https://graphql.org/learn/schema/#input-types)