### PR TITLE
Fix issue where merging two similarly populated Json objects would throw

### DIFF
--- a/source/graphql/helper.d
+++ b/source/graphql/helper.d
@@ -248,9 +248,12 @@ Json joinJson(JoinJsonPrecedence jjp = JoinJsonPrecedence.none)(Json a, Json b)
 				ret[key] = joinJson(*ap, value);
 			} else {
 				static if(jjp == JoinJsonPrecedence.none) {
-					throw new Exception(format(
+					// only an error if the values aren't the same
+					if(ap.type != value.type || *ap != value) {
+						throw new Exception(format(
 							"Can not join '%s' and '%s' on key '%s'",
 							ap.type, value.type, key));
+					}
 				} else static if(jjp == JoinJsonPrecedence.a) {
 				} else {
 					ret[key] = value;


### PR DESCRIPTION
an error even if they matched.

For some reason, when getting one aggregate in a query, this function was called, and was throwing this error, even though the fields of the two Json objects were identical.

Also, this was difficult to find. The exception thrown is caught internally, and unless logging is turned on, no indication of anything wrong is displayed by the library. The end result was that an array of values was completely cancelled, and instead of the aggregate, I got an empty array (not even an empty array of the aggregate which failed to merge, it was the owning aggregate).

I figured if you want to merge two Json objects, and the fields already were the same, there is no error.

I admit, I don't understand why for this route/selection it triggered this code. I cannot follow how this code works at all. But doing this extra check fixes my error. This is sort of a punt. Happy to investigate further, but I need help understanding what is going on here.

Please let me know if I got this wrong.