### PR TITLE
Array resolver

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -10,6 +10,7 @@
 		"nullablestore": ">=2.1.0"
 	},
 	"dflags": [ "-d"],
+	"dflags-ldc": ["-d", "-ftime-trace", "-ftime-trace-file=$PACKAGE_DIR/trace.json", "-wi"],
 	"description": "A library to handle the GraphQL Protocol",
 	"copyright": "Copyright © 2019, Robert burner Schadek",
 	"license": "LGPL3"

--- a/source/graphql/builder.d
+++ b/source/graphql/builder.d
@@ -5,6 +5,7 @@ version(LDC) {
 } else {
 	import std.logger : logf;
 }
+import std.array : back, empty;
 import std.exception : enforce;
 import std.format : format;
 
@@ -125,7 +126,7 @@ struct FieldRangeItem {
 }
 
 struct FieldRange {
-	FixedSizeArray!(Selections,64) cur;
+	Selections[] cur;
 	Document doc;
 	string[] typenames;
 	Json vars;
@@ -134,7 +135,7 @@ struct FieldRange {
 		this.doc = doc;
 		this.typenames = typenames;
 		this.vars = vars;
-		this.cur.insertBack(sels);
+		this.cur ~= sels;
 		this.build();
 		//this.test();
 	}
@@ -183,7 +184,6 @@ struct FieldRange {
 			if(se == SelectionEnum.Field) {
 				return;
 			} else {
-				Selections follow = this.cur.back.follow;
 				Selections f = se == SelectionEnum.Spread
 					? findFragment(doc, this.cur.back.sel.frag.name.value,
 							this.typenames
@@ -192,21 +192,22 @@ struct FieldRange {
 							this.typenames
 						);
 
-				this.cur.removeBack();
+				Selections follow = this.cur.back.follow;
+				this.cur = this.cur[0 .. $ - 1];
 
 				if(follow !is null) {
-					this.cur.insertBack(follow);
+					this.cur ~= follow;
 					this.build();
 					//this.test();
 				}
 				if(f !is null) {
-					this.cur.insertBack(f);
+					this.cur ~= f;
 					this.build();
 					//this.test();
 				}
 			}
 		} else if(this.cur.back is null) {
-			this.cur.removeBack();
+			this.cur = this.cur[0 .. $ - 1];
 			this.build();
 		} else {
 			this.cur.back = this.cur.back.follow;

--- a/source/graphql/graphql.d
+++ b/source/graphql/graphql.d
@@ -67,7 +67,7 @@ class GraphQLD(T, QContext = DefaultContext) {
 	alias QueryResolver = Json delegate(string name, Json parent,
 			Json args, ref Con context) @safe;
 	alias QueryArrayResolver = Json delegate(string name, ParentArgs parentArgs
-			, Selections selections, ref Con context) @safe;
+			, Field selections, ref Con context) @safe;
 
 	alias DefaultQueryResolver = Json delegate(string name, Json parent,
 			Json args, ref Con context, ref ExecutionContext ec) @safe;
@@ -466,7 +466,10 @@ class GraphQLD(T, QContext = DefaultContext) {
 
 		this.executationTraceLog.logf("elemType %s", elemType);
 		Json ret = returnTemplate();
-		QueryArrayResolver[string]* arrayTypeResolverArray = unPacked.name in this.arrayResolver;
+		QueryArrayResolver[string]* arrayTypeResolverArray =
+			unPacked !is null
+				? unPacked.name in this.arrayResolver
+				: null;
 		GQLDMap elemTypeMap = toMap(unPacked);
 
 		if(arrayTypeResolverArray !is null) {
@@ -486,6 +489,11 @@ class GraphQLD(T, QContext = DefaultContext) {
 				writefln("Array Resolver %s %s %s", unPacked.name
 						, arrayTypeResolver !is null
 						, field.name);
+				if(arrayTypeResolver !is null) {
+					Json rslt = (*arrayTypeResolver)(field.name
+							, ParentArgs(objectValue, variables)
+							, field.f, context);
+				}
 			}
 		}
 

--- a/source/graphql/graphql.d
+++ b/source/graphql/graphql.d
@@ -463,8 +463,10 @@ class GraphQLD(T, QContext = DefaultContext) {
 				ret[Constants.errors] = err;
 			}
 		} else if(!tmp.dataIsEmpty() && tmp.isScalar()) {
-			insertPayload(ret, tmp);
-			//ret["data"] = tmp;
+			writefln("toRun2 before %s %s", ret, tmp);
+			//insertPayload(ret, tmp);
+			ret["data"] = tmp;
+			writefln("toRun2 after %s", ret);
 		}
 	}
 

--- a/source/graphql/graphql.d
+++ b/source/graphql/graphql.d
@@ -463,9 +463,6 @@ class GraphQLD(T, QContext = DefaultContext) {
 		enforce("data" in objectValue, "Excepted object got " ~ objectValue.toString());
 		GQLDType elemType = objectType.elementType;
 		GQLDType unPacked = unpack2(elemType);
-		Selections ssSelCopy = ss is null
-			? null
-			: shallowCopy(ss.sel);
 
 		this.executationTraceLog.logf("elemType %s", elemType);
 		Json ret = returnTemplate();
@@ -476,17 +473,12 @@ class GraphQLD(T, QContext = DefaultContext) {
 		GQLDMap elemTypeMap = toMap(unPacked);
 
 		if(arrayTypeResolverArray !is null) {
-			foreach(FieldRangeItem field;
-					fieldRangeArr(
-						ss.sel,
-						doc,
-						interfacesForType(this.schema
-							, objectValue.getWithDefault!string(
-								"data.__typename", "__typename")
-							),
-						variables)
-				)
-			{
+			FieldRange fr = fieldRange(ss, doc
+					, interfacesForType(this.schema
+						, objectValue.getWithDefault!string("data.__typename"
+						, "__typename"))
+					, variables, BuildLinear.yes);
+			for(FieldRangeItem =
 				QueryArrayResolver* arrayTypeResolver =
 					field.name in (*arrayTypeResolverArray);
 				writefln("Array Resolver %s %s %s", unPacked.name

--- a/source/graphql/graphql.d
+++ b/source/graphql/graphql.d
@@ -532,6 +532,11 @@ class GraphQLD(T, QContext = DefaultContext) {
 				//		, field.name
 				//		, arrayTypeResolver !is null);
 				if(arrayTypeResolver !is null) {
+					string fieldName = field.aka.empty ? field.name : field.aka;
+					ec.path ~= PathElement(fieldName);
+					scope(exit) {
+						ec.path.popBack();
+					}
 					FieldRangeItem[] fri = fieldRangeArr(field.f.ss.sel, doc
 						, interfacesForType(this.schema
 							, objectValue.getWithDefault!string("data.__typename"
@@ -558,9 +563,7 @@ class GraphQLD(T, QContext = DefaultContext) {
 					//writefln("objV %s\nrslt %s", objectValue.toPrettyString()
 					//		, rslt.toPrettyString());
 
-					string fieldName = field.aka.empty ? field.name : field.aka;
 					auto rsltType = this.schema.getReturnType(unPacked, fieldName);
-					auto rsltTypeUn = unpackNonList(rsltType);
 					//writefln("%s\n%s", rsltType, rsltTypeUn);
 
 					size_t idx;
@@ -575,7 +578,7 @@ class GraphQLD(T, QContext = DefaultContext) {
 							++idx;
 						}
 						//writefln("iter %s %s", idx, item.toPrettyString());
-						this.toRunArrayResolverFollow(fieldName, field.f.ss, rsltTypeUn
+						this.toRunArrayResolverFollow(fieldName, field.f.ss, rsltType
 								, item, results[idx], variables, doc, context, ec);
 					}
 					//joinInArray(ret, rslt, fieldName);

--- a/source/graphql/graphql.d
+++ b/source/graphql/graphql.d
@@ -454,19 +454,13 @@ class GraphQLD(T, QContext = DefaultContext) {
 			);
 		if(tmp.type == Json.Type.object) {
 			if("data" in tmp) {
-				writefln("toRun before %s %s", ret, tmp);
 				insertPayload(ret, tmp);
-				writefln("toRun after %s", ret);
-				//ret["data"] = tmp["data"];
 			}
 			foreach(err; tmp[Constants.errors]) {
 				ret[Constants.errors] = err;
 			}
 		} else if(!tmp.dataIsEmpty() && tmp.isScalar()) {
-			writefln("toRun2 before %s %s", ret, tmp);
-			//insertPayload(ret, tmp);
 			ret["data"] = tmp;
-			writefln("toRun2 after %s", ret);
 		}
 	}
 
@@ -475,60 +469,20 @@ class GraphQLD(T, QContext = DefaultContext) {
 			, ref ExecutionContext ec) @trusted
 	{
 		auto t = Json(["data": item]);
-		writefln("to send down %s", t.toPrettyString());
+		//writefln("to send down %s", t.toPrettyString());
 		Json tmp = this.executeSelectionSet(ss, elemType, t, variables,
 				doc, context, ec
 			);
-		/*
-		tmp = tmp.type == Json.Type.object && "data" in tmp
-			? tmp["data"]
-			: tmp;
-		*/
 
-		writefln("join tmp %s\n ret %s", tmp.toPrettyString(), ret.toPrettyString());
-		/*if(tmp.type == Json.Type.object) {
-			if("data" in tmp) {
-				ret["data"][fieldName] = tmp["data"];
-				//insertPayload(ret["data"], fieldName, tmp["data"]);
-				//ret["data"] = tmp["data"];
-			}
-			//foreach(err; tmp[Constants.errors]) {
-			//	ret[Constants.errors] = err;
-			//}
-		} else if(!tmp.dataIsEmpty() && tmp.isScalar()) {
-			ret["data"][fieldName] = tmp;
-		}*/
+		//writefln("join tmp %s\n ret %s", tmp.toPrettyString(), ret.toPrettyString());
 		elemType = elemType.unpackNonList();
-		writefln("elemType %s", elemType);
+		//writefln("elemType %s", elemType);
 		if(GQLDList l = elemType.toList()) {
 			enforce(tmp.type == Json.Type.object, "Expected Object got "
 					~ tmp.toPrettyString());
-			writefln("before %s %s", ret, tmp);
 			insertPayload(ret, fieldName, tmp);
-			writefln("after %s", ret);
-			/*
-			foreach(it; "data" in tmp ? tmp["data"] : tmp) {
-				insertPayload(ret, fieldName, it);
-				writefln("after %s", ret);
-				//if("data" in tmp) {
-				//	ret["data"] ~= tmp["data"];
-				//}
-				//foreach(err; tmp[Constants.errors]) {
-				//	ret.insertError(err);
-				//	//ret[Constants.errors] ~= err;
-				//}
-			}
-			*/
 		} else {
-			writefln("o before %s %s", ret, tmp);
 			insertPayload(ret, fieldName, tmp);
-			writefln("o after %s", ret);
-			//if("data" in tmp) {
-			//	ret["data"] ~= tmp["data"];
-			//}
-			//foreach(err; tmp[Constants.errors]) {
-			//	ret[Constants.errors] ~= err;
-			//}
 		}
 	}
 
@@ -574,9 +528,9 @@ class GraphQLD(T, QContext = DefaultContext) {
 				QueryArrayResolver* arrayTypeResolver =
 					field.name in (*arrayTypeResolverArray);
 
-				writefln("Array Resolver %s.%s %s", unPacked.name
-						, field.name
-						, arrayTypeResolver !is null);
+				//writefln("Array Resolver %s.%s %s", unPacked.name
+				//		, field.name
+				//		, arrayTypeResolver !is null);
 				if(arrayTypeResolver !is null) {
 					FieldRangeItem[] fri = fieldRangeArr(field.f.ss.sel, doc
 						, interfacesForType(this.schema
@@ -601,13 +555,13 @@ class GraphQLD(T, QContext = DefaultContext) {
 							.toPrettyString());
 					//objectValue[field.name] = rslt;
 
-					writefln("objV %s\nrslt %s", objectValue.toPrettyString()
-							, rslt.toPrettyString());
+					//writefln("objV %s\nrslt %s", objectValue.toPrettyString()
+					//		, rslt.toPrettyString());
 
 					string fieldName = field.aka.empty ? field.name : field.aka;
 					auto rsltType = this.schema.getReturnType(unPacked, fieldName);
 					auto rsltTypeUn = unpackNonList(rsltType);
-					writefln("%s\n%s", rsltType, rsltTypeUn);
+					//writefln("%s\n%s", rsltType, rsltTypeUn);
 
 					size_t idx;
 					foreach(ref Json item;
@@ -620,7 +574,7 @@ class GraphQLD(T, QContext = DefaultContext) {
 							ec.path.popBack();
 							++idx;
 						}
-						writefln("iter %s %s", idx, item.toPrettyString());
+						//writefln("iter %s %s", idx, item.toPrettyString());
 						this.toRunArrayResolverFollow(fieldName, field.f.ss, rsltTypeUn
 								, item, results[idx], variables, doc, context, ec);
 					}
@@ -630,8 +584,8 @@ class GraphQLD(T, QContext = DefaultContext) {
 				}
 			}
 		}
-		writefln("already handled %s", fieldsHandledByArrayResolver);
-		writefln("after ArrayResolver %s", Json(results).toPrettyString());
+		//writefln("already handled %s", fieldsHandledByArrayResolver);
+		//writefln("after ArrayResolver %s", Json(results).toPrettyString());
 
 		if(this.options.asyncList == AsyncList.yes) {
 			Task[] tasks;
@@ -669,13 +623,13 @@ class GraphQLD(T, QContext = DefaultContext) {
 			}
 		}
 		foreach(idx, ref it; results) {
-			writefln("final join %s %s", idx, it.toPrettyString());
+			//writefln("final join %s %s", idx, it.toPrettyString());
 			ret["data"] ~= it["data"];
 			if(it["errors"].length > 0) {
 				ret["errors"] ~= it["errors"];
 			}
 		}
-		writefln("return %s", ret.toPrettyString());
+		//writefln("return %s", ret.toPrettyString());
 		return ret;
 	}
 }

--- a/source/graphql/graphql.d
+++ b/source/graphql/graphql.d
@@ -463,6 +463,9 @@ class GraphQLD(T, QContext = DefaultContext) {
 		enforce("data" in objectValue, "Excepted object got " ~ objectValue.toString());
 		GQLDType elemType = objectType.elementType;
 		GQLDType unPacked = unpack2(elemType);
+		Selections ssSelCopy = ss is null
+			? null
+			: shallowCopy(ss.sel);
 
 		this.executationTraceLog.logf("elemType %s", elemType);
 		Json ret = returnTemplate();

--- a/source/graphql/graphql.d
+++ b/source/graphql/graphql.d
@@ -479,9 +479,9 @@ class GraphQLD(T, QContext = DefaultContext) {
 					ret["data"] ~= tmp["data"];
 				}
 				foreach(err; tmp[Constants.errors]) {
-					ret[Constants.errors] ~= err;
+					ret.insertError(err);
+					//ret[Constants.errors] ~= err;
 				}
-				writeln(ret["data"].toPrettyString());
 			}
 		} else {
 			Json tmp = this.executeSelectionSet(ss, elemType, item, variables,
@@ -581,9 +581,9 @@ class GraphQLD(T, QContext = DefaultContext) {
 							ec.path.popBack();
 						}
 						this.toRunArrayResolverFollow(field.f.ss, rsltTypeUn
-								, item, ret, variables, doc, context, ec);
+								, item, rslt, variables, doc, context, ec);
 					}
-					//joinInArray(ret, rslt, fieldName);
+					joinInArray(ret, rslt, fieldName);
 					//return ret;
 					//writeln(ret.toPrettyString());
 				}

--- a/source/graphql/helper.d
+++ b/source/graphql/helper.d
@@ -1108,9 +1108,11 @@ GQLDType[string] allMember(GQLDMap m) @safe {
 }
 
 SelectionSet shallowCopy(SelectionSet s) {
-	SelectionSet ret = new SelectionSet();
-	ret.ruleSelection = s.ruleSelection;
-	ret.sel = shallowCopy(s.sel);
+	if(s is null) {
+		return null;
+	}
+	SelectionSet ret = new SelectionSet(s.ruleSelection
+			, shallowCopy(s.sel));
 	return ret;
 }
 
@@ -1118,10 +1120,9 @@ private Selections shallowCopy(Selections s) {
 	if(s is null) {
 		return null;
 	} else {
-		Selections ret = new Selections();
-		ret.ruleSelection = s.ruleSelection();
-		ret.sel = s.sel;
-		ret.follow = shallowCopy(s.follow);
+		Selections ret = new Selections(s.ruleSelection
+				, s.sel
+				, shallowCopy(s.follow));
 		return ret;
 	}
 }

--- a/source/graphql/helper.d
+++ b/source/graphql/helper.d
@@ -109,7 +109,7 @@ void insertPayload(ref Json result, Json data) @trusted {
 			result[d] = Json.emptyObject();
 		}
 		enforce(result[d].type == Json.Type.object);
-		foreach(string key, ref Json value; data) {
+		foreach(string key, ref Json value; data[d]) {
 			Json* df = key in result[d];
 			if(df) {
 				result[d][key] = joinJson(*df, value);

--- a/source/graphql/helper.d
+++ b/source/graphql/helper.d
@@ -83,12 +83,39 @@ void insertPayload(ref Json result, string field, Json data) {
 		if(d !in result) {
 			result[d] = Json.emptyObject();
 		}
-		enforce(result[d].type == Json.Type.object);
+		enforce(result[d].type == Json.Type.object, "Expected Json.Type.object"
+				~ " got " ~ result[d].toPrettyString());
 		Json* df = field in result[d];
 		if(df) {
 			result[d][field] = joinJson(*df, data[d]);
 		} else {
 			result[d][field] = data[d];
+		}
+	}
+	if(e in data) {
+		if(e !in result) {
+			result[e] = Json.emptyArray();
+		}
+		enforce(result[e].type == Json.Type.array);
+		if(!canFind(result[e].byValue(), data[e])) {
+			result[e] ~= data[e];
+		}
+	}
+}
+
+void insertPayload(ref Json result, Json data) @trusted {
+	if(d in data) {
+		if(d !in result) {
+			result[d] = Json.emptyObject();
+		}
+		enforce(result[d].type == Json.Type.object);
+		foreach(string key, ref Json value; data) {
+			Json* df = key in result[d];
+			if(df) {
+				result[d][key] = joinJson(*df, value);
+			} else {
+				result[d][key] = value;
+			}
 		}
 	}
 	if(e in data) {

--- a/source/graphql/helper.d
+++ b/source/graphql/helper.d
@@ -272,10 +272,10 @@ unittest {
 	f = j.getWithPath2("name.foo");
 	enforce(f.to!int() == 13);
 
-	Json h = j.getWithPath("doesnotexist");
+	Json h = j.getWithPath2("doesnotexist");
 	assert(h.type == Json.Type.null_);
 
-	h = j.getWithPath("name.alsoNotThere");
+	h = j.getWithPath2("name.alsoNotThere");
 	assert(h.type == Json.Type.null_);
 }
 

--- a/source/graphql/helper.d
+++ b/source/graphql/helper.d
@@ -1107,3 +1107,21 @@ GQLDType[string] allMember(GQLDMap m) @safe {
 	return ret;
 }
 
+SelectionSet shallowCopy(SelectionSet s) {
+	SelectionSet ret = new SelectionSet();
+	ret.ruleSelection = s.ruleSelection;
+	ret.sel = shallowCopy(s.sel);
+	return ret;
+}
+
+private Selections shallowCopy(Selections s) {
+	if(s is null) {
+		return null;
+	} else {
+		Selections ret = new Selections();
+		ret.ruleSelection = s.ruleSelection();
+		ret.sel = s.sel;
+		ret.follow = shallowCopy(s.follow);
+		return ret;
+	}
+}

--- a/source/graphql/helper.d
+++ b/source/graphql/helper.d
@@ -250,9 +250,9 @@ Json getWithPath2(Json input, string path) {
 	auto sp = path.splitter(".");
 	foreach(s; sp) {
 		Json* n = s in input;
-        if(n is null || (*n).type == Json.Type.null_) {
-            return Json(null);
-        }
+		if(n is null || (*n).type == Json.Type.null_) {
+			return Json(null);
+		}
 		input = *n;
 	}
 	return input;

--- a/source/graphql/helper.d
+++ b/source/graphql/helper.d
@@ -1106,23 +1106,3 @@ GQLDType[string] allMember(GQLDMap m) @safe {
 	process(m);
 	return ret;
 }
-
-SelectionSet shallowCopy(SelectionSet s) {
-	if(s is null) {
-		return null;
-	}
-	SelectionSet ret = new SelectionSet(s.ruleSelection
-			, shallowCopy(s.sel));
-	return ret;
-}
-
-private Selections shallowCopy(Selections s) {
-	if(s is null) {
-		return null;
-	} else {
-		Selections ret = new Selections(s.ruleSelection
-				, s.sel
-				, shallowCopy(s.follow));
-		return ret;
-	}
-}

--- a/source/graphql/schema/typeconversions.d
+++ b/source/graphql/schema/typeconversions.d
@@ -21,7 +21,7 @@ import graphql.uda;
 import graphql.constants;
 
 private enum memsToIgnore = ["__ctor", "toString", "toHash", "opCmp",
-                             "opEquals", "Monitor", "factory", "opAssign"];
+		"opEquals", "Monitor", "factory", "opAssign"];
 @safe:
 
 template typeToTypeEnum(Type) {

--- a/source/graphql/schema/types.d
+++ b/source/graphql/schema/types.d
@@ -972,6 +972,17 @@ GQLDType unpack2(GQLDType t) {
 	return t;
 }
 
+GQLDType unpackNonList(GQLDType t) {
+	if(GQLDNonNull nn = toNonNull(t)) {
+		return unpackNonList(nn.elementType);
+	} else if(GQLDNullable nn = toNullable(t)) {
+		return unpackNonList(nn.elementType);
+	} else if(GQLDOperation nn = toOperation(t)) {
+		return unpackNonList(nn.returnType);
+	}
+	return t;
+}
+
 unittest {
 	int a;
 	GQLDType i = typeToGQLDType!(int)(a, true);

--- a/source/graphql/testschema.d
+++ b/source/graphql/testschema.d
@@ -59,7 +59,7 @@ struct Query {
 	Starship[] starships(float overSize = 100.0);
 	Starship[] shipsselection(long[] ids);
 	Nullable!Character character(long id);
-	Character[] character(Series series);
+	Character[] characters(Series series);
 	Humanoid[] humanoids();
 	Android[] androids();
 	Android[] resolverWillThrow();

--- a/test/schema.gql
+++ b/test/schema.gql
@@ -10,13 +10,14 @@ type mutationType {
 }
 type queryType {
 	shipsselection(ids: [Int!]!): [Starship!]!
-	currentTime: DateTime!
+	characters(series: Series!): [Character!]!
 	starships(overSize: Float!): [Starship!]!
 	captain(series: Series!): Character!
 	humanoids: [Humanoid!]!
-	name: String!
+	currentTime: DateTime!
 	starship(id: Int!): Starship
 	starshipSimple2(id: Int!): StarshipSimple2
+	name: String!
 	androids: [Android!]!
 	resolverWillThrow: [Android!]!
 	numberBetween(searchInput: InputIn!): Starship!

--- a/test/source/app.d
+++ b/test/source/app.d
@@ -381,9 +381,9 @@ void main() {
 
 	graphqld.setArrayResolver("Character", "commands",
 		delegate(string name, ParentArgs parentArgs
-			, Selections selection, ref CustomContext context) @trusted
+			, Field field, ref CustomContext context) @trusted
 		{
-			writefln("HEERRRRRRR %s %s %s", name, parentArgs, selection);
+			writefln("HEERRRRRRR %s %s %s", name, parentArgs, field);
 			Json ret = Json.emptyObject();
 			return ret;
 		}

--- a/test/source/app.d
+++ b/test/source/app.d
@@ -372,6 +372,19 @@ void main() {
 							data ~= characterToJson(c.front);
 						}
 					}
+				} else if("id" in parent) {
+					long id = parent["id"].get!long();
+					foreach(ref it; database.chars
+							.filter!(jt => jt.id == id)
+						)
+					{
+						foreach(ht; it.commands) {
+							//auto c = database.chars.filter!(jt => jt.id == ht.id);
+							//if(!c.empty) {
+								data ~= characterToJson(ht);
+							//}
+						}
+					}
 				}
 				Json ret = Json.emptyObject();
 				ret["data"] = data;
@@ -413,6 +426,7 @@ void main() {
 									g[v.key] = v.value;
 								}
 							}
+							g["commandsIds"] = t["commandsIds"];
 							return g;
 						}())
 						.array;

--- a/test/source/app.d
+++ b/test/source/app.d
@@ -408,7 +408,6 @@ void main() {
 						.map!(ht => () @trusted {
 							Json t = characterToJson(ht);
 							Json g = Json.emptyObject();
-							g["data"] = Json.emptyObject();
 							foreach(v; t["data"].byKeyValue) {
 								if(canFind(keysToKeep, v.key)) {
 									g[v.key] = v.value;

--- a/test/source/app.d
+++ b/test/source/app.d
@@ -83,8 +83,8 @@ void main() {
 	} else {
 		graphqld.defaultResolverLog.logLevel = std.logger.LogLevel.off;
 		graphqld.resolverLog.logLevel = std.logger.LogLevel.off;
-		graphqld.executationTraceLog = new std.experimental.logger.FileLogger("exec.log");
-		graphqld.executationTraceLog.logLevel = std.logger.LogLevel.trace;
+		//graphqld.executationTraceLog = new std.experimental.logger.FileLogger("exec.log");
+		//graphqld.executationTraceLog.logLevel = std.logger.LogLevel.trace;
 	}
 
 	testSchemaDump("schema.gql", schemaToString(graphqld));

--- a/test/source/testdata.d
+++ b/test/source/testdata.d
@@ -55,7 +55,8 @@ Json characterToJson(Character c) {
 
 	if(Humanoid h = cast(Humanoid)c) {
 		ret["data"]["species"] = h.species;
-		ret["data"]["__typename"] = "Humanoid";
+		//ret["data"]["__typename"] = "Humanoid"; TODO reverse hack
+		ret["data"]["__typename"] = "Character";
 		ret["data"]["dateOfBirth"] = Json(h.dateOfBirth.toISOExtString());
 	}
 


### PR DESCRIPTION
if there is a query where the first level returns an array the second level resolver should be only called once. This resolver should then return an array matching the size of the first level query result.