### PR TITLE
Fix parsing fields with names matching alphanumeric tokens

### DIFF
--- a/graphql.yaml
+++ b/graphql.yaml
@@ -65,8 +65,29 @@ Field:
     F: [FieldName#name]
 
 FieldName:
-    A: [name#name, colon, name#aka]
-    N: [name#name]
+    A: [Identifier#name, colon, name#aka]
+    N: [Identifier#name]
+
+Identifier:
+    I: [name#tok]
+    "Mutation": [mutation#tok]
+    "Subscription": [subscription#tok]
+    "Scalar": [scalar#tok]
+    "Schema": [schema#tok]
+    "On": [on_#tok]
+    "Directive": [directive#tok]
+    "Enum": [enum_#tok]
+    "Extend": [extend#tok]
+    "Input": [input#tok]
+    "Interface": [interface_#tok]
+    "Implements": [implements#tok]
+    "False": [false_#tok]
+    "Fragment": [fragment#tok]
+    "Query": [query#tok]
+    "True": [true_#tok]
+    "Type": [type#tok]
+    "Null": [null_#tok]
+    "Union": [union_#tok]
 
 Arguments:
     List: [lparen, ArgumentList#arg, rparen]
@@ -204,16 +225,16 @@ FieldDefinitions:
     FNC: [FieldDefinition#fd, FieldDefinitions#follow]
 
 FieldDefinition:
-    AD: [name#name, ArgumentsDefinition#arg, colon, Type#typ,
+    AD: [Identifier#name, ArgumentsDefinition#arg, colon, Type#typ,
         Directives#dir]
-    A: [name#name, ArgumentsDefinition#arg, colon, Type#typ]
-    D: [name#name, colon, Type#typ, Directives#dir]
-    T: [name#name, colon, Type#typ]
-    DAD: [Description#des, name#name, ArgumentsDefinition#arg, colon, Type#typ,
+    A: [Identifier#name, ArgumentsDefinition#arg, colon, Type#typ]
+    D: [Identifier#name, colon, Type#typ, Directives#dir]
+    T: [Identifier#name, colon, Type#typ]
+    DAD: [Description#des, Identifier#name, ArgumentsDefinition#arg, colon, Type#typ,
         Directives#dir]
-    DA: [Description#des, name#name, ArgumentsDefinition#arg, colon, Type#typ]
-    DD: [Description#des, name#name, colon, Type#typ, Directives#dir]
-    DT: [Description#des, name#name, colon, Type#typ]
+    DA: [Description#des, Identifier#name, ArgumentsDefinition#arg, colon, Type#typ]
+    DD: [Description#des, Identifier#name, colon, Type#typ, Directives#dir]
+    DT: [Description#des, Identifier#name, colon, Type#typ]
 
 ImplementsInterfaces:
     N: [implements, NamedTypes#nts]
@@ -233,14 +254,14 @@ InputValueDefinitions:
     IF: [InputValueDefinition#iv, InputValueDefinitions#follow]
 
 InputValueDefinition:
-    TVD: [name#name, colon, Type#type, DefaultValue#df, Directives#dirs]
-    TD: [name#name, colon, Type#type, Directives#dirs]
-    TV: [name#name, colon, Type#type, DefaultValue#df]
-    T: [name#name, colon, Type#type]
-    DTVD: [Description#des, name#name, colon, Type#type, DefaultValue#df, Directives#dirs]
-    DTD: [Description#des, name#name, colon, Type#type, Directives#dirs]
-    DTV: [Description#des, name#name, colon, Type#type, DefaultValue#df]
-    DT: [Description#des, name#name, colon, Type#type]
+    TVD: [Identifier#name, colon, Type#type, DefaultValue#df, Directives#dirs]
+    TD: [Identifier#name, colon, Type#type, Directives#dirs]
+    TV: [Identifier#name, colon, Type#type, DefaultValue#df]
+    T: [Identifier#name, colon, Type#type]
+    DTVD: [Description#des, Identifier#name, colon, Type#type, DefaultValue#df, Directives#dirs]
+    DTD: [Description#des, Identifier#name, colon, Type#type, Directives#dirs]
+    DTV: [Description#des, Identifier#name, colon, Type#type, DefaultValue#df]
+    DT: [Description#des, Identifier#name, colon, Type#type]
 
 InterfaceTypeDefinition:
     NDF: [interface_, name#name, Directives#dirs, lcurly,

--- a/source/graphql/ast.d
+++ b/source/graphql/ast.d
@@ -578,17 +578,67 @@ class FieldName : Node {
 
 	FieldNameEnum ruleSelection;
 	Token aka;
-	Token name;
+	Identifier name;
 
-	this(FieldNameEnum ruleSelection, Token name, Token aka) {
+	this(FieldNameEnum ruleSelection, Identifier name, Token aka) {
 		this.ruleSelection = ruleSelection;
 		this.name = name;
 		this.aka = aka;
 	}
 
-	this(FieldNameEnum ruleSelection, Token name) {
+	this(FieldNameEnum ruleSelection, Identifier name) {
 		this.ruleSelection = ruleSelection;
 		this.name = name;
+	}
+
+	void visit(Visitor vis) {
+		vis.accept(this);
+	}
+
+	void visit(Visitor vis) const {
+		vis.accept(this);
+	}
+
+	void visit(ConstVisitor vis) {
+		vis.accept(this);
+	}
+
+	void visit(ConstVisitor vis) const {
+		vis.accept(this);
+	}
+}
+
+enum IdentifierEnum {
+	I,
+	Mutation,
+	Subscription,
+	Scalar,
+	Schema,
+	On,
+	Directive,
+	Enum,
+	Extend,
+	Input,
+	Interface,
+	Implements,
+	False,
+	Fragment,
+	Query,
+	True,
+	Type,
+	Null,
+	Union,
+}
+
+class Identifier : Node {
+@safe :
+
+	IdentifierEnum ruleSelection;
+	Token tok;
+
+	this(IdentifierEnum ruleSelection, Token tok) {
+		this.ruleSelection = ruleSelection;
+		this.tok = tok;
 	}
 
 	void visit(Visitor vis) {
@@ -1774,9 +1824,9 @@ class FieldDefinition : Node {
 	ArgumentsDefinition arg;
 	Type typ;
 	Directives dir;
-	Token name;
+	Identifier name;
 
-	this(FieldDefinitionEnum ruleSelection, Token name, ArgumentsDefinition arg, Type typ, Directives dir) {
+	this(FieldDefinitionEnum ruleSelection, Identifier name, ArgumentsDefinition arg, Type typ, Directives dir) {
 		this.ruleSelection = ruleSelection;
 		this.name = name;
 		this.arg = arg;
@@ -1784,27 +1834,27 @@ class FieldDefinition : Node {
 		this.dir = dir;
 	}
 
-	this(FieldDefinitionEnum ruleSelection, Token name, ArgumentsDefinition arg, Type typ) {
+	this(FieldDefinitionEnum ruleSelection, Identifier name, ArgumentsDefinition arg, Type typ) {
 		this.ruleSelection = ruleSelection;
 		this.name = name;
 		this.arg = arg;
 		this.typ = typ;
 	}
 
-	this(FieldDefinitionEnum ruleSelection, Token name, Type typ, Directives dir) {
+	this(FieldDefinitionEnum ruleSelection, Identifier name, Type typ, Directives dir) {
 		this.ruleSelection = ruleSelection;
 		this.name = name;
 		this.typ = typ;
 		this.dir = dir;
 	}
 
-	this(FieldDefinitionEnum ruleSelection, Token name, Type typ) {
+	this(FieldDefinitionEnum ruleSelection, Identifier name, Type typ) {
 		this.ruleSelection = ruleSelection;
 		this.name = name;
 		this.typ = typ;
 	}
 
-	this(FieldDefinitionEnum ruleSelection, Description des, Token name, ArgumentsDefinition arg, Type typ, Directives dir) {
+	this(FieldDefinitionEnum ruleSelection, Description des, Identifier name, ArgumentsDefinition arg, Type typ, Directives dir) {
 		this.ruleSelection = ruleSelection;
 		this.des = des;
 		this.name = name;
@@ -1813,7 +1863,7 @@ class FieldDefinition : Node {
 		this.dir = dir;
 	}
 
-	this(FieldDefinitionEnum ruleSelection, Description des, Token name, ArgumentsDefinition arg, Type typ) {
+	this(FieldDefinitionEnum ruleSelection, Description des, Identifier name, ArgumentsDefinition arg, Type typ) {
 		this.ruleSelection = ruleSelection;
 		this.des = des;
 		this.name = name;
@@ -1821,7 +1871,7 @@ class FieldDefinition : Node {
 		this.typ = typ;
 	}
 
-	this(FieldDefinitionEnum ruleSelection, Description des, Token name, Type typ, Directives dir) {
+	this(FieldDefinitionEnum ruleSelection, Description des, Identifier name, Type typ, Directives dir) {
 		this.ruleSelection = ruleSelection;
 		this.des = des;
 		this.name = name;
@@ -1829,7 +1879,7 @@ class FieldDefinition : Node {
 		this.dir = dir;
 	}
 
-	this(FieldDefinitionEnum ruleSelection, Description des, Token name, Type typ) {
+	this(FieldDefinitionEnum ruleSelection, Description des, Identifier name, Type typ) {
 		this.ruleSelection = ruleSelection;
 		this.des = des;
 		this.name = name;
@@ -2017,9 +2067,9 @@ class InputValueDefinition : Node {
 	Description des;
 	DefaultValue df;
 	Directives dirs;
-	Token name;
+	Identifier name;
 
-	this(InputValueDefinitionEnum ruleSelection, Token name, Type type, DefaultValue df, Directives dirs) {
+	this(InputValueDefinitionEnum ruleSelection, Identifier name, Type type, DefaultValue df, Directives dirs) {
 		this.ruleSelection = ruleSelection;
 		this.name = name;
 		this.type = type;
@@ -2027,27 +2077,27 @@ class InputValueDefinition : Node {
 		this.dirs = dirs;
 	}
 
-	this(InputValueDefinitionEnum ruleSelection, Token name, Type type, Directives dirs) {
+	this(InputValueDefinitionEnum ruleSelection, Identifier name, Type type, Directives dirs) {
 		this.ruleSelection = ruleSelection;
 		this.name = name;
 		this.type = type;
 		this.dirs = dirs;
 	}
 
-	this(InputValueDefinitionEnum ruleSelection, Token name, Type type, DefaultValue df) {
+	this(InputValueDefinitionEnum ruleSelection, Identifier name, Type type, DefaultValue df) {
 		this.ruleSelection = ruleSelection;
 		this.name = name;
 		this.type = type;
 		this.df = df;
 	}
 
-	this(InputValueDefinitionEnum ruleSelection, Token name, Type type) {
+	this(InputValueDefinitionEnum ruleSelection, Identifier name, Type type) {
 		this.ruleSelection = ruleSelection;
 		this.name = name;
 		this.type = type;
 	}
 
-	this(InputValueDefinitionEnum ruleSelection, Description des, Token name, Type type, DefaultValue df, Directives dirs) {
+	this(InputValueDefinitionEnum ruleSelection, Description des, Identifier name, Type type, DefaultValue df, Directives dirs) {
 		this.ruleSelection = ruleSelection;
 		this.des = des;
 		this.name = name;
@@ -2056,7 +2106,7 @@ class InputValueDefinition : Node {
 		this.dirs = dirs;
 	}
 
-	this(InputValueDefinitionEnum ruleSelection, Description des, Token name, Type type, Directives dirs) {
+	this(InputValueDefinitionEnum ruleSelection, Description des, Identifier name, Type type, Directives dirs) {
 		this.ruleSelection = ruleSelection;
 		this.des = des;
 		this.name = name;
@@ -2064,7 +2114,7 @@ class InputValueDefinition : Node {
 		this.dirs = dirs;
 	}
 
-	this(InputValueDefinitionEnum ruleSelection, Description des, Token name, Type type, DefaultValue df) {
+	this(InputValueDefinitionEnum ruleSelection, Description des, Identifier name, Type type, DefaultValue df) {
 		this.ruleSelection = ruleSelection;
 		this.des = des;
 		this.name = name;
@@ -2072,7 +2122,7 @@ class InputValueDefinition : Node {
 		this.df = df;
 	}
 
-	this(InputValueDefinitionEnum ruleSelection, Description des, Token name, Type type) {
+	this(InputValueDefinitionEnum ruleSelection, Description des, Identifier name, Type type) {
 		this.ruleSelection = ruleSelection;
 		this.des = des;
 		this.name = name;

--- a/source/graphql/astselector.d
+++ b/source/graphql/astselector.d
@@ -109,7 +109,7 @@ class AstSelector : ConstVisitor {
 			this.popStack(shouldPop);
 		}
 
-		shouldPop = this.takeName(obj.name.name.value, obj);
+		shouldPop = this.takeName(obj.name.name.tok.value, obj);
 
 		if(shouldPop) {
 			if(obj.args !is null) {
@@ -193,7 +193,7 @@ query foo {
 	auto d = lexAndParse(s);
 	auto a = d.astSelect!Field("foo.a");
 	assert(a !is null);
-	assert(a.name.name.value == "a");
+	assert(a.name.name.tok.value == "a");
 }
 
 unittest {
@@ -254,7 +254,7 @@ mutation a {
 	auto d = lexAndParse(s);
 	auto foo = d.astSelect!Field("foo.a.b");
 	assert(foo !is null);
-	assert(foo.name.name.value == "b");
+	assert(foo.name.name.tok.value == "b");
 }
 
 unittest {

--- a/source/graphql/builder.d
+++ b/source/graphql/builder.d
@@ -105,7 +105,7 @@ fragment fooo on Hero {
 
 	auto f = findFragment(d, "fooo", ["Hero"]);
 	assert(f !is null);
-	assert(f.sel.field.name.name.value == "name");
+	assert(f.sel.field.name.name.tok.value == "name");
 
 	f = findFragment(d, "fooo", ["Villian"]);
 	assert(f is null);
@@ -119,8 +119,8 @@ struct FieldRangeItem {
 	Document doc;
 
 	@property string name() {
-		return f.name.name.value;
-		//return f.name.aka.value.empty ? f.name.name.value : f.name.aka.value;
+		return f.name.name.tok.value;
+		//return f.name.aka.value.empty ? f.name.name.tok.value : f.name.aka.value;
 	}
 
 	@property string aka() {

--- a/source/graphql/graphql.d
+++ b/source/graphql/graphql.d
@@ -323,7 +323,7 @@ class GraphQLD(T, QContext = DefaultContext) {
 					)
 				: Json.emptyObject();
 
-			const string name = field.f.name.name.value;
+			const string name = field.f.name.name.tok.value;
 			ret.insertPayload(name, rslt);
 		}
 		return ret;
@@ -333,7 +333,7 @@ class GraphQLD(T, QContext = DefaultContext) {
 			Json objectValue, Json variables, Document doc, ref Con context,
 			ref ExecutionContext ec)
 	{
-		ec.path ~= PathElement(field.f.name.name.value);
+		ec.path ~= PathElement(field.f.name.name.tok.value);
 		scope(exit) {
 			ec.path.popBack();
 		}

--- a/source/graphql/parser.d
+++ b/source/graphql/parser.d
@@ -437,7 +437,7 @@ struct Parser {
 			throw new ParseException(app.data,
 				__FILE__, __LINE__,
 				subRules,
-				["dots -> Selection","name -> Selection"]
+				["directive -> Selection","dots -> Selection","enum_ -> Selection","extend -> Selection","false_ -> Selection","fragment -> Selection","implements -> Selection","input -> Selection","interface_ -> Selection","mutation -> Selection","name -> Selection","null_ -> Selection","on_ -> Selection","query -> Selection","scalar -> Selection","schema -> Selection","subscription -> Selection","true_ -> Selection","type -> Selection","union_ -> Selection"]
 			);
 
 		}
@@ -556,7 +556,7 @@ struct Parser {
 				throw new ParseException(app.data,
 					__FILE__, __LINE__,
 					subRules,
-					["dots -> Selection","name -> Selection"]
+					["directive -> Selection","dots -> Selection","enum_ -> Selection","extend -> Selection","false_ -> Selection","fragment -> Selection","implements -> Selection","input -> Selection","interface_ -> Selection","mutation -> Selection","name -> Selection","null_ -> Selection","on_ -> Selection","query -> Selection","scalar -> Selection","schema -> Selection","subscription -> Selection","true_ -> Selection","type -> Selection","union_ -> Selection"]
 				);
 
 			}
@@ -572,7 +572,7 @@ struct Parser {
 		throw new ParseException(app.data,
 			__FILE__, __LINE__,
 			subRules,
-			["dots","name -> Field"]
+			["directive -> Field","dots","enum_ -> Field","extend -> Field","false_ -> Field","fragment -> Field","implements -> Field","input -> Field","interface_ -> Field","mutation -> Field","name -> Field","null_ -> Field","on_ -> Field","query -> Field","scalar -> Field","schema -> Field","subscription -> Field","true_ -> Field","type -> Field","union_ -> Field"]
 		);
 
 	}
@@ -638,7 +638,7 @@ struct Parser {
 		throw new ParseException(app.data,
 			__FILE__, __LINE__,
 			subRules,
-			["name -> FieldName","dots"]
+			["directive -> FieldName","enum_ -> FieldName","extend -> FieldName","false_ -> FieldName","fragment -> FieldName","implements -> FieldName","input -> FieldName","interface_ -> FieldName","mutation -> FieldName","name -> FieldName","null_ -> FieldName","on_ -> FieldName","query -> FieldName","scalar -> FieldName","schema -> FieldName","subscription -> FieldName","true_ -> FieldName","type -> FieldName","union_ -> FieldName","dots"]
 		);
 
 	}
@@ -904,13 +904,13 @@ struct Parser {
 		throw new ParseException(app.data,
 			__FILE__, __LINE__,
 			subRules,
-			["name"]
+			["directive -> Identifier","enum_ -> Identifier","extend -> Identifier","false_ -> Identifier","fragment -> Identifier","implements -> Identifier","input -> Identifier","interface_ -> Identifier","mutation -> Identifier","name -> Identifier","null_ -> Identifier","on_ -> Identifier","query -> Identifier","scalar -> Identifier","schema -> Identifier","subscription -> Identifier","true_ -> Identifier","type -> Identifier","union_ -> Identifier"]
 		);
 
 	}
 
 	bool firstFieldName() const pure @nogc @safe {
-		return this.lex.front.type == TokenType.name;
+		return this.firstIdentifier();
 	}
 
 	FieldName parseFieldName() {
@@ -927,9 +927,8 @@ struct Parser {
 	FieldName parseFieldNameImpl() {
 		string[] subRules;
 		subRules = ["A", "N"];
-		if(this.lex.front.type == TokenType.name) {
-			Token name = this.lex.front;
-			this.lex.popFront();
+		if(this.firstIdentifier()) {
+			Identifier name = this.parseIdentifier();
 			subRules = ["A"];
 			if(this.lex.front.type == TokenType.colon) {
 				this.lex.popFront();
@@ -967,7 +966,190 @@ struct Parser {
 		throw new ParseException(app.data,
 			__FILE__, __LINE__,
 			subRules,
-			["name"]
+			["directive","enum_","extend","false_","fragment","implements","input","interface_","mutation","name","null_","on_","query","scalar","schema","subscription","true_","type","union_"]
+		);
+
+	}
+
+	bool firstIdentifier() const pure @nogc @safe {
+		return this.lex.front.type == TokenType.name
+			 || this.lex.front.type == TokenType.mutation
+			 || this.lex.front.type == TokenType.subscription
+			 || this.lex.front.type == TokenType.scalar
+			 || this.lex.front.type == TokenType.schema
+			 || this.lex.front.type == TokenType.on_
+			 || this.lex.front.type == TokenType.directive
+			 || this.lex.front.type == TokenType.enum_
+			 || this.lex.front.type == TokenType.extend
+			 || this.lex.front.type == TokenType.input
+			 || this.lex.front.type == TokenType.interface_
+			 || this.lex.front.type == TokenType.implements
+			 || this.lex.front.type == TokenType.false_
+			 || this.lex.front.type == TokenType.fragment
+			 || this.lex.front.type == TokenType.query
+			 || this.lex.front.type == TokenType.true_
+			 || this.lex.front.type == TokenType.type
+			 || this.lex.front.type == TokenType.null_
+			 || this.lex.front.type == TokenType.union_;
+	}
+
+	Identifier parseIdentifier() {
+		try {
+			return this.parseIdentifierImpl();
+		} catch(ParseException e) {
+			throw new ParseException(
+				"While parsing a Identifier an Exception was thrown.",
+				e, __FILE__, __LINE__
+			);
+		}
+	}
+
+	Identifier parseIdentifierImpl() {
+		string[] subRules;
+		subRules = ["I"];
+		if(this.lex.front.type == TokenType.name) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.I
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.mutation) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Mutation
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.subscription) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Subscription
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.scalar) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Scalar
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.schema) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Schema
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.on_) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.On
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.directive) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Directive
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.enum_) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Enum
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.extend) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Extend
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.input) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Input
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.interface_) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Interface
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.implements) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Implements
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.false_) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.False
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.fragment) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Fragment
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.query) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Query
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.true_) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.True
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.type) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Type
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.null_) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Null
+				, tok
+			);
+		} else if(this.lex.front.type == TokenType.union_) {
+			Token tok = this.lex.front;
+			this.lex.popFront();
+
+			return new Identifier(IdentifierEnum.Union
+				, tok
+			);
+		}
+		auto app = appender!string();
+		formattedWrite(app, 
+			"In 'Identifier' found a '%s' while looking for", 
+			this.lex.front
+		);
+		throw new ParseException(app.data,
+			__FILE__, __LINE__,
+			subRules,
+			["name","mutation","subscription","scalar","schema","on_","directive","enum_","extend","input","interface_","implements","false_","fragment","query","true_","type","null_","union_"]
 		);
 
 	}
@@ -2906,7 +3088,7 @@ struct Parser {
 							throw new ParseException(app.data,
 								__FILE__, __LINE__,
 								subRules,
-								["name -> FieldDefinition","stringValue -> FieldDefinition"]
+								["directive -> FieldDefinition","enum_ -> FieldDefinition","extend -> FieldDefinition","false_ -> FieldDefinition","fragment -> FieldDefinition","implements -> FieldDefinition","input -> FieldDefinition","interface_ -> FieldDefinition","mutation -> FieldDefinition","name -> FieldDefinition","null_ -> FieldDefinition","on_ -> FieldDefinition","query -> FieldDefinition","scalar -> FieldDefinition","schema -> FieldDefinition","stringValue -> FieldDefinition","subscription -> FieldDefinition","true_ -> FieldDefinition","type -> FieldDefinition","union_ -> FieldDefinition"]
 							);
 
 						}
@@ -2956,7 +3138,7 @@ struct Parser {
 						throw new ParseException(app.data,
 							__FILE__, __LINE__,
 							subRules,
-							["name -> FieldDefinition","stringValue -> FieldDefinition"]
+							["directive -> FieldDefinition","enum_ -> FieldDefinition","extend -> FieldDefinition","false_ -> FieldDefinition","fragment -> FieldDefinition","implements -> FieldDefinition","input -> FieldDefinition","interface_ -> FieldDefinition","mutation -> FieldDefinition","name -> FieldDefinition","null_ -> FieldDefinition","on_ -> FieldDefinition","query -> FieldDefinition","scalar -> FieldDefinition","schema -> FieldDefinition","stringValue -> FieldDefinition","subscription -> FieldDefinition","true_ -> FieldDefinition","type -> FieldDefinition","union_ -> FieldDefinition"]
 						);
 
 					}
@@ -3009,7 +3191,7 @@ struct Parser {
 						throw new ParseException(app.data,
 							__FILE__, __LINE__,
 							subRules,
-							["name -> FieldDefinition","stringValue -> FieldDefinition"]
+							["directive -> FieldDefinition","enum_ -> FieldDefinition","extend -> FieldDefinition","false_ -> FieldDefinition","fragment -> FieldDefinition","implements -> FieldDefinition","input -> FieldDefinition","interface_ -> FieldDefinition","mutation -> FieldDefinition","name -> FieldDefinition","null_ -> FieldDefinition","on_ -> FieldDefinition","query -> FieldDefinition","scalar -> FieldDefinition","schema -> FieldDefinition","stringValue -> FieldDefinition","subscription -> FieldDefinition","true_ -> FieldDefinition","type -> FieldDefinition","union_ -> FieldDefinition"]
 						);
 
 					}
@@ -3058,7 +3240,7 @@ struct Parser {
 					throw new ParseException(app.data,
 						__FILE__, __LINE__,
 						subRules,
-						["name -> FieldDefinition","stringValue -> FieldDefinition"]
+						["directive -> FieldDefinition","enum_ -> FieldDefinition","extend -> FieldDefinition","false_ -> FieldDefinition","fragment -> FieldDefinition","implements -> FieldDefinition","input -> FieldDefinition","interface_ -> FieldDefinition","mutation -> FieldDefinition","name -> FieldDefinition","null_ -> FieldDefinition","on_ -> FieldDefinition","query -> FieldDefinition","scalar -> FieldDefinition","schema -> FieldDefinition","stringValue -> FieldDefinition","subscription -> FieldDefinition","true_ -> FieldDefinition","type -> FieldDefinition","union_ -> FieldDefinition"]
 					);
 
 				}
@@ -3139,7 +3321,7 @@ struct Parser {
 				throw new ParseException(app.data,
 					__FILE__, __LINE__,
 					subRules,
-					["name -> FieldDefinition","stringValue -> FieldDefinition"]
+					["directive -> FieldDefinition","enum_ -> FieldDefinition","extend -> FieldDefinition","false_ -> FieldDefinition","fragment -> FieldDefinition","implements -> FieldDefinition","input -> FieldDefinition","interface_ -> FieldDefinition","mutation -> FieldDefinition","name -> FieldDefinition","null_ -> FieldDefinition","on_ -> FieldDefinition","query -> FieldDefinition","scalar -> FieldDefinition","schema -> FieldDefinition","stringValue -> FieldDefinition","subscription -> FieldDefinition","true_ -> FieldDefinition","type -> FieldDefinition","union_ -> FieldDefinition"]
 				);
 
 			} else if(this.firstFieldDefinitions()) {
@@ -3162,13 +3344,13 @@ struct Parser {
 		throw new ParseException(app.data,
 			__FILE__, __LINE__,
 			subRules,
-			["name","stringValue -> Description"]
+			["directive -> Identifier","enum_ -> Identifier","extend -> Identifier","false_ -> Identifier","fragment -> Identifier","implements -> Identifier","input -> Identifier","interface_ -> Identifier","mutation -> Identifier","name -> Identifier","null_ -> Identifier","on_ -> Identifier","query -> Identifier","scalar -> Identifier","schema -> Identifier","stringValue -> Description","subscription -> Identifier","true_ -> Identifier","type -> Identifier","union_ -> Identifier"]
 		);
 
 	}
 
 	bool firstFieldDefinition() const pure @nogc @safe {
-		return this.lex.front.type == TokenType.name
+		return this.firstIdentifier()
 			 || this.firstDescription();
 	}
 
@@ -3186,9 +3368,8 @@ struct Parser {
 	FieldDefinition parseFieldDefinitionImpl() {
 		string[] subRules;
 		subRules = ["A", "AD", "D", "T"];
-		if(this.lex.front.type == TokenType.name) {
-			Token name = this.lex.front;
-			this.lex.popFront();
+		if(this.firstIdentifier()) {
+			Identifier name = this.parseIdentifier();
 			subRules = ["A", "AD"];
 			if(this.firstArgumentsDefinition()) {
 				ArgumentsDefinition arg = this.parseArgumentsDefinition();
@@ -3284,9 +3465,8 @@ struct Parser {
 		} else if(this.firstDescription()) {
 			Description des = this.parseDescription();
 			subRules = ["DA", "DAD", "DD", "DT"];
-			if(this.lex.front.type == TokenType.name) {
-				Token name = this.lex.front;
-				this.lex.popFront();
+			if(this.firstIdentifier()) {
+				Identifier name = this.parseIdentifier();
 				subRules = ["DA", "DAD"];
 				if(this.firstArgumentsDefinition()) {
 					ArgumentsDefinition arg = this.parseArgumentsDefinition();
@@ -3392,7 +3572,7 @@ struct Parser {
 			throw new ParseException(app.data,
 				__FILE__, __LINE__,
 				subRules,
-				["name"]
+				["directive","enum_","extend","false_","fragment","implements","input","interface_","mutation","name","null_","on_","query","scalar","schema","subscription","true_","type","union_"]
 			);
 
 		}
@@ -3404,7 +3584,7 @@ struct Parser {
 		throw new ParseException(app.data,
 			__FILE__, __LINE__,
 			subRules,
-			["name","stringValue"]
+			["directive","enum_","extend","false_","fragment","implements","input","interface_","mutation","name","null_","on_","query","scalar","schema","subscription","true_","type","union_","stringValue"]
 		);
 
 	}
@@ -3586,7 +3766,7 @@ struct Parser {
 			throw new ParseException(app.data,
 				__FILE__, __LINE__,
 				subRules,
-				["name -> InputValueDefinition","stringValue -> InputValueDefinition","rparen"]
+				["directive -> InputValueDefinition","enum_ -> InputValueDefinition","extend -> InputValueDefinition","false_ -> InputValueDefinition","fragment -> InputValueDefinition","implements -> InputValueDefinition","input -> InputValueDefinition","interface_ -> InputValueDefinition","mutation -> InputValueDefinition","name -> InputValueDefinition","null_ -> InputValueDefinition","on_ -> InputValueDefinition","query -> InputValueDefinition","scalar -> InputValueDefinition","schema -> InputValueDefinition","stringValue -> InputValueDefinition","subscription -> InputValueDefinition","true_ -> InputValueDefinition","type -> InputValueDefinition","union_ -> InputValueDefinition","rparen"]
 			);
 
 		}
@@ -3643,7 +3823,7 @@ struct Parser {
 				throw new ParseException(app.data,
 					__FILE__, __LINE__,
 					subRules,
-					["name -> InputValueDefinition","stringValue -> InputValueDefinition"]
+					["directive -> InputValueDefinition","enum_ -> InputValueDefinition","extend -> InputValueDefinition","false_ -> InputValueDefinition","fragment -> InputValueDefinition","implements -> InputValueDefinition","input -> InputValueDefinition","interface_ -> InputValueDefinition","mutation -> InputValueDefinition","name -> InputValueDefinition","null_ -> InputValueDefinition","on_ -> InputValueDefinition","query -> InputValueDefinition","scalar -> InputValueDefinition","schema -> InputValueDefinition","stringValue -> InputValueDefinition","subscription -> InputValueDefinition","true_ -> InputValueDefinition","type -> InputValueDefinition","union_ -> InputValueDefinition"]
 				);
 
 			} else if(this.firstInputValueDefinitions()) {
@@ -3666,13 +3846,13 @@ struct Parser {
 		throw new ParseException(app.data,
 			__FILE__, __LINE__,
 			subRules,
-			["name","stringValue -> Description"]
+			["directive -> Identifier","enum_ -> Identifier","extend -> Identifier","false_ -> Identifier","fragment -> Identifier","implements -> Identifier","input -> Identifier","interface_ -> Identifier","mutation -> Identifier","name -> Identifier","null_ -> Identifier","on_ -> Identifier","query -> Identifier","scalar -> Identifier","schema -> Identifier","stringValue -> Description","subscription -> Identifier","true_ -> Identifier","type -> Identifier","union_ -> Identifier"]
 		);
 
 	}
 
 	bool firstInputValueDefinition() const pure @nogc @safe {
-		return this.lex.front.type == TokenType.name
+		return this.firstIdentifier()
 			 || this.firstDescription();
 	}
 
@@ -3690,9 +3870,8 @@ struct Parser {
 	InputValueDefinition parseInputValueDefinitionImpl() {
 		string[] subRules;
 		subRules = ["T", "TD", "TV", "TVD"];
-		if(this.lex.front.type == TokenType.name) {
-			Token name = this.lex.front;
-			this.lex.popFront();
+		if(this.firstIdentifier()) {
+			Identifier name = this.parseIdentifier();
 			subRules = ["T", "TD", "TV", "TVD"];
 			if(this.lex.front.type == TokenType.colon) {
 				this.lex.popFront();
@@ -3758,9 +3937,8 @@ struct Parser {
 		} else if(this.firstDescription()) {
 			Description des = this.parseDescription();
 			subRules = ["DT", "DTD", "DTV", "DTVD"];
-			if(this.lex.front.type == TokenType.name) {
-				Token name = this.lex.front;
-				this.lex.popFront();
+			if(this.firstIdentifier()) {
+				Identifier name = this.parseIdentifier();
 				subRules = ["DT", "DTD", "DTV", "DTVD"];
 				if(this.lex.front.type == TokenType.colon) {
 					this.lex.popFront();
@@ -3836,7 +4014,7 @@ struct Parser {
 			throw new ParseException(app.data,
 				__FILE__, __LINE__,
 				subRules,
-				["name"]
+				["directive","enum_","extend","false_","fragment","implements","input","interface_","mutation","name","null_","on_","query","scalar","schema","subscription","true_","type","union_"]
 			);
 
 		}
@@ -3848,7 +4026,7 @@ struct Parser {
 		throw new ParseException(app.data,
 			__FILE__, __LINE__,
 			subRules,
-			["name","stringValue"]
+			["directive","enum_","extend","false_","fragment","implements","input","interface_","mutation","name","null_","on_","query","scalar","schema","subscription","true_","type","union_","stringValue"]
 		);
 
 	}
@@ -3916,7 +4094,7 @@ struct Parser {
 						throw new ParseException(app.data,
 							__FILE__, __LINE__,
 							subRules,
-							["name -> FieldDefinition","stringValue -> FieldDefinition"]
+							["directive -> FieldDefinition","enum_ -> FieldDefinition","extend -> FieldDefinition","false_ -> FieldDefinition","fragment -> FieldDefinition","implements -> FieldDefinition","input -> FieldDefinition","interface_ -> FieldDefinition","mutation -> FieldDefinition","name -> FieldDefinition","null_ -> FieldDefinition","on_ -> FieldDefinition","query -> FieldDefinition","scalar -> FieldDefinition","schema -> FieldDefinition","stringValue -> FieldDefinition","subscription -> FieldDefinition","true_ -> FieldDefinition","type -> FieldDefinition","union_ -> FieldDefinition"]
 						);
 
 					}
@@ -3965,7 +4143,7 @@ struct Parser {
 					throw new ParseException(app.data,
 						__FILE__, __LINE__,
 						subRules,
-						["name -> FieldDefinition","stringValue -> FieldDefinition"]
+						["directive -> FieldDefinition","enum_ -> FieldDefinition","extend -> FieldDefinition","false_ -> FieldDefinition","fragment -> FieldDefinition","implements -> FieldDefinition","input -> FieldDefinition","interface_ -> FieldDefinition","mutation -> FieldDefinition","name -> FieldDefinition","null_ -> FieldDefinition","on_ -> FieldDefinition","query -> FieldDefinition","scalar -> FieldDefinition","schema -> FieldDefinition","stringValue -> FieldDefinition","subscription -> FieldDefinition","true_ -> FieldDefinition","type -> FieldDefinition","union_ -> FieldDefinition"]
 					);
 
 				}
@@ -4562,7 +4740,7 @@ struct Parser {
 						throw new ParseException(app.data,
 							__FILE__, __LINE__,
 							subRules,
-							["name -> InputValueDefinition","stringValue -> InputValueDefinition"]
+							["directive -> InputValueDefinition","enum_ -> InputValueDefinition","extend -> InputValueDefinition","false_ -> InputValueDefinition","fragment -> InputValueDefinition","implements -> InputValueDefinition","input -> InputValueDefinition","interface_ -> InputValueDefinition","mutation -> InputValueDefinition","name -> InputValueDefinition","null_ -> InputValueDefinition","on_ -> InputValueDefinition","query -> InputValueDefinition","scalar -> InputValueDefinition","schema -> InputValueDefinition","stringValue -> InputValueDefinition","subscription -> InputValueDefinition","true_ -> InputValueDefinition","type -> InputValueDefinition","union_ -> InputValueDefinition"]
 						);
 
 					}
@@ -4611,7 +4789,7 @@ struct Parser {
 					throw new ParseException(app.data,
 						__FILE__, __LINE__,
 						subRules,
-						["name -> InputValueDefinition","stringValue -> InputValueDefinition"]
+						["directive -> InputValueDefinition","enum_ -> InputValueDefinition","extend -> InputValueDefinition","false_ -> InputValueDefinition","fragment -> InputValueDefinition","implements -> InputValueDefinition","input -> InputValueDefinition","interface_ -> InputValueDefinition","mutation -> InputValueDefinition","name -> InputValueDefinition","null_ -> InputValueDefinition","on_ -> InputValueDefinition","query -> InputValueDefinition","scalar -> InputValueDefinition","schema -> InputValueDefinition","stringValue -> InputValueDefinition","subscription -> InputValueDefinition","true_ -> InputValueDefinition","type -> InputValueDefinition","union_ -> InputValueDefinition"]
 					);
 
 				}
@@ -4974,7 +5152,7 @@ struct Parser {
 						throw new ParseException(app.data,
 							__FILE__, __LINE__,
 							subRules,
-							["name -> InputValueDefinition","stringValue -> InputValueDefinition"]
+							["directive -> InputValueDefinition","enum_ -> InputValueDefinition","extend -> InputValueDefinition","false_ -> InputValueDefinition","fragment -> InputValueDefinition","implements -> InputValueDefinition","input -> InputValueDefinition","interface_ -> InputValueDefinition","mutation -> InputValueDefinition","name -> InputValueDefinition","null_ -> InputValueDefinition","on_ -> InputValueDefinition","query -> InputValueDefinition","scalar -> InputValueDefinition","schema -> InputValueDefinition","stringValue -> InputValueDefinition","subscription -> InputValueDefinition","true_ -> InputValueDefinition","type -> InputValueDefinition","union_ -> InputValueDefinition"]
 						);
 
 					}
@@ -5022,7 +5200,7 @@ struct Parser {
 					throw new ParseException(app.data,
 						__FILE__, __LINE__,
 						subRules,
-						["name -> InputValueDefinition","stringValue -> InputValueDefinition"]
+						["directive -> InputValueDefinition","enum_ -> InputValueDefinition","extend -> InputValueDefinition","false_ -> InputValueDefinition","fragment -> InputValueDefinition","implements -> InputValueDefinition","input -> InputValueDefinition","interface_ -> InputValueDefinition","mutation -> InputValueDefinition","name -> InputValueDefinition","null_ -> InputValueDefinition","on_ -> InputValueDefinition","query -> InputValueDefinition","scalar -> InputValueDefinition","schema -> InputValueDefinition","stringValue -> InputValueDefinition","subscription -> InputValueDefinition","true_ -> InputValueDefinition","type -> InputValueDefinition","union_ -> InputValueDefinition"]
 					);
 
 				}

--- a/source/graphql/parsertests.d
+++ b/source/graphql/parsertests.d
@@ -490,6 +490,28 @@ input ApproveDeploymentsInput {
 }
 `);
 
+	tests ~= TestCase(34, QueryParser.no, `
+type TestType {
+  input: String!
+  type: String!
+  query: String!
+}
+
+input TestInput {
+  input: String!
+  type: String!
+  query: String!
+}
+`);
+
+	tests ~= TestCase(35, QueryParser.yes, `
+query {
+  input
+  type
+  query
+}
+`);
+
 	foreach(test; tests) {
 		auto l = Lexer(test.str, test.qp);
 		auto p = Parser(l);

--- a/source/graphql/tokenmodule.d
+++ b/source/graphql/tokenmodule.d
@@ -26,7 +26,7 @@ enum TokenType {
 	subscription,
 	fragment,
 	on_,
-	alias_,
+	// alias_,
 	true_,
 	false_,
 	null_,
@@ -35,18 +35,64 @@ enum TokenType {
 	union_,
 	type,
 	typename,
-	skip,
-	include_,
+	// skip,
+	// include_,
 	input,
 	scalar,
 	schema,
-	schema__,
+	// schema__,
 	directive,
 	enum_,
 	interface_,
 	implements,
 	extend,
 }
+
+static immutable string[cast(TokenType)(TokenType.max + 1)] tokenStrings = [
+	null,
+	"!",
+	"$",
+	"(",
+	")",
+	"...",
+	":",
+	"=",
+	"@",
+	"[",
+	"]",
+	"{",
+	"}",
+	"|",
+	null,
+	null,
+	null,
+	null,
+	"query",
+	"mutation",
+	"subscription",
+	"fragment",
+	"on",
+	// "alias",
+	"true",
+	"false",
+	"null",
+	null,
+	",",
+	"union",
+	"type",
+	"__typename",
+	// "skip",
+	// "include",
+	"input",
+	"scalar",
+	"schema",
+	// "__schema",
+	"directive",
+	"enum",
+	"interface",
+	"implements",
+	"extend",
+];
 
 struct Token {
 @safe:
@@ -58,10 +104,11 @@ struct Token {
 
 	this(TokenType type) {
 		this.type = type;
+		this.value = tokenStrings[type];
 	}
 
 	this(TokenType type, size_t line, size_t column) {
-		this.type = type;
+		this(type);
 		this.line = cast(uint)line;
 		this.column = cast(ushort)column;
 	}

--- a/source/graphql/treevisitor.d
+++ b/source/graphql/treevisitor.d
@@ -120,6 +120,14 @@ class TreeVisitor : ConstVisitor {
 		--this.depth;
 	}
 
+	override void accept(const(Identifier) obj) {
+		this.genIndent();
+		writeln(Unqual!(typeof(obj)).stringof,":", obj.ruleSelection);
+		++this.depth;
+		super.accept(obj);
+		--this.depth;
+	}
+
 	override void accept(const(Arguments) obj) {
 		this.genIndent();
 		writeln(Unqual!(typeof(obj)).stringof,":", obj.ruleSelection);

--- a/source/graphql/validation/schemabased.d
+++ b/source/graphql/validation/schemabased.d
@@ -251,7 +251,7 @@ class SchemaValidator(Schema) : Visitor {
 				(this.schemaStack.back.type.typeKind == TypeKind.SCALAR
 				|| this.schemaStack.back.type.typeKind == TypeKind.ENUM),
 				format("Leaf field '%s' is not a SCALAR nor ENUM but '%s'. Stack %s. Back %s"
-					, f.name.name.value
+					, f.name.name.tok.value
 					, this.schemaStack.back.type.typeKind
 					, this.schemaStack.map!(it => format("%s.%s", it.name, it.fieldName))
 					, this.schemaStack.back.type
@@ -261,7 +261,7 @@ class SchemaValidator(Schema) : Visitor {
 
 	override void enter(const(FieldName) fn) {
 		import std.array : empty;
-		string n = fn.aka.value.empty ? fn.name.value : fn.aka.value;
+		string n = fn.aka.value.empty ? fn.name.tok.value : fn.aka.value;
 		this.addToTypeStack(n);
 	}
 
@@ -928,4 +928,3 @@ subscription sub {
 
 	test!SingleRootField(str);
 }
-

--- a/source/graphql/visitor.d
+++ b/source/graphql/visitor.d
@@ -297,6 +297,73 @@ class Visitor : ConstVisitor {
 		exit(obj);
 	}
 
+	void enter(Identifier obj) {}
+	void exit(Identifier obj) {}
+
+	void accept(Identifier obj) {
+		enter(obj);
+		final switch(obj.ruleSelection) {
+			case IdentifierEnum.I:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Mutation:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Subscription:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Scalar:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Schema:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.On:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Directive:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Enum:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Extend:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Input:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Interface:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Implements:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.False:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Fragment:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Query:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.True:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Type:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Null:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Union:
+				obj.tok.visit(this);
+				break;
+		}
+		exit(obj);
+	}
+
 	void enter(Arguments obj) {}
 	void exit(Arguments obj) {}
 
@@ -1518,6 +1585,73 @@ class ConstVisitor {
 				break;
 			case FieldNameEnum.N:
 				obj.name.visit(this);
+				break;
+		}
+		exit(obj);
+	}
+
+	void enter(const(Identifier) obj) {}
+	void exit(const(Identifier) obj) {}
+
+	void accept(const(Identifier) obj) {
+		enter(obj);
+		final switch(obj.ruleSelection) {
+			case IdentifierEnum.I:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Mutation:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Subscription:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Scalar:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Schema:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.On:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Directive:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Enum:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Extend:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Input:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Interface:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Implements:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.False:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Fragment:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Query:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.True:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Type:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Null:
+				obj.tok.visit(this);
+				break;
+			case IdentifierEnum.Union:
+				obj.tok.visit(this);
 				break;
 		}
 		exit(obj);


### PR DESCRIPTION
GraphQL does not really have "reserved keywords" as such, so field names such as "input", "type" and "query" are valid.

This commit explicitly enumerates alphabetic tokens as valid field names.

This is a bit of a hack and probably should be solved more properly in Darser.

(Draft because I would like to test serialization first, but I haven't implemented it yet.)