### PR TITLE
graphql.lexer: Allow parsing "subscription" in query parser mode

### DIFF
--- a/source/graphql/lexer.d
+++ b/source/graphql/lexer.d
@@ -180,8 +180,7 @@ struct Lexer {
 					++this.stringPos;
 					++this.column;
 					++e;
-					if(this.isNotQueryParser() &&
-							this.testStrAndInc!"ubscription"(e))
+					if(this.testStrAndInc!"ubscription"(e))
 					{
 						if(this.isTokenStop()) {
 							this.cur =


### PR DESCRIPTION
Allow parsing subscription queries.

Even though graphqld does not support subscriptions itself, this enables other GraphQL libraries which do to use it for lexing and parsing.